### PR TITLE
core/bumping-dependency-vue-version (#729)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "upgrade:vue": "bash ./scripts/update-versions.sh"
   },
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",
@@ -46,7 +46,7 @@
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
     "@vue/babel-plugin-jsx": "^1.0.0-rc.3",
-    "@vue/compiler-sfc": "^3.0.0",
+    "@vue/compiler-sfc": "^3.0.3",
     "@vue/component-compiler-utils": "^3.2.0",
     "algoliasearch": "^4.4.0",
     "babel-jest": "^26.3.0",
@@ -92,8 +92,8 @@
     "ts-loader": "^8.0.3",
     "typescript": "^4.0.2",
     "url-loader": "^4.1.0",
-    "vue-jest": "5.0.0-alpha.1",
-    "vue-loader": "16.0.0-beta.7",
+    "vue-jest": "5.0.0-alpha.5",
+    "vue-loader": "^16.1.0",
     "vue-router": "^4.0.0-beta.4",
     "vue-template-compiler": "^2.6.12",
     "webpack": "^4.44.1",

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/aside/package.json
+++ b/packages/aside/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/backtop/package.json
+++ b/packages/backtop/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@element-plus/button": "^0.0.0",

--- a/packages/breadcrumb-item/package.json
+++ b/packages/breadcrumb-item/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/carousel-item/package.json
+++ b/packages/carousel-item/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/cascader-panel/package.json
+++ b/packages/cascader-panel/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/cascader/package.json
+++ b/packages/cascader/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/checkbox-button/package.json
+++ b/packages/checkbox-button/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/col/package.json
+++ b/packages/col/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/collapse-item/package.json
+++ b/packages/collapse-item/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/collapse-transition/package.json
+++ b/packages/collapse-transition/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/collapse/package.json
+++ b/packages/collapse/package.json
@@ -8,7 +8,7 @@
     "@element-plus/utils": "^0.0.0"
   },
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/color-picker/package.json
+++ b/packages/color-picker/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/directives/package.json
+++ b/packages/directives/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/dropdown-item/package.json
+++ b/packages/dropdown-item/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/dropdown-menu/package.json
+++ b/packages/dropdown-menu/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/form-item/package.json
+++ b/packages/form-item/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/infinite-scroll/package.json
+++ b/packages/infinite-scroll/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/input-number/package.json
+++ b/packages/input-number/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/loading/package.json
+++ b/packages/loading/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/locale/package.json
+++ b/packages/locale/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/menu-item-group/package.json
+++ b/packages/menu-item-group/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/menu-item/package.json
+++ b/packages/menu-item/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0-rc.9"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/message-box/package.json
+++ b/packages/message-box/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0-rc.7"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/message/package.json
+++ b/packages/message/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/option-group/package.json
+++ b/packages/option-group/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/option/package.json
+++ b/packages/option/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/page-header/package.json
+++ b/packages/page-header/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0-rc.1"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/popconfirm/package.json
+++ b/packages/popconfirm/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0-rc.1"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/popper/__tests__/popper.spec.ts
+++ b/packages/popper/__tests__/popper.spec.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import * as Vue from 'vue'
 import * as popperExports from '@popperjs/core'
+import { rAF } from '@element-plus/test-utils/tick'
 import ElPopper from '../src/index.vue'
 
 import type { VueWrapper } from '@vue/test-utils'
@@ -24,8 +25,7 @@ const DISPLAY_NONE = 'display: none'
 const Wrapped = (props: UnknownProps, { slots }) => {
   return h('div', h(ElPopper, props, slots))
 }
-const Transition = (_: UnknownProps, { attrs, slots }) => h('div', attrs, slots)
-Transition.displayName = 'Transition'
+
 // eslint-disable-next-line
 const _mount = (props: UnknownProps = {}, slots = {}): VueWrapper<any> =>
   mount(Wrapped, {
@@ -51,14 +51,9 @@ const popperMock = jest
   }))
 
 describe('Popper.vue', () => {
-  const oldTransition = Vue.Transition
-  beforeAll(() => {
-    (Vue as any).Transition = Transition
-  })
 
   afterAll(() => {
     popperMock.mockReset()
-    ;(Vue as any).Transition = oldTransition
   })
 
   beforeEach(() => {
@@ -218,10 +213,15 @@ describe('Popper.vue', () => {
     })
     const $trigger = wrapper.find(`.${TEST_TRIGGER}`)
     await $trigger.trigger(MOUSE_ENTER_EVENT)
+    await rAF()
+    await nextTick()
     expect(wrapper.find(selector).attributes('style')).not.toContain(
       DISPLAY_NONE,
     )
+
+    await $trigger.trigger(MOUSE_LEAVE_EVENT)
     jest.runOnlyPendingTimers()
+    await rAF()
     await nextTick()
     expect(wrapper.find(selector).attributes('style')).toContain(DISPLAY_NONE)
   })

--- a/packages/popper/package.json
+++ b/packages/popper/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/popper/src/index.vue
+++ b/packages/popper/src/index.vue
@@ -25,12 +25,10 @@ import { ClickOutside } from '@element-plus/directives'
 const compName = 'ElPopper'
 const UPDATE_VISIBLE_EVENT = 'update:visible'
 
-const emits = [UPDATE_VISIBLE_EVENT, 'after-enter', 'after-leave']
-
 export default defineComponent({
   name: compName,
   props: defaultProps,
-  emits,
+  emits: [UPDATE_VISIBLE_EVENT, 'after-enter', 'after-leave', 'before-enter', 'before-leave'],
   setup(props, ctx) {
     if (!ctx.slots.trigger) {
       throwError(compName, 'Trigger must be provided')
@@ -61,6 +59,8 @@ export default defineComponent({
       onPopperMouseLeave,
       onAfterEnter,
       onAfterLeave,
+      onBeforeEnter,
+      onBeforeLeave,
       popperClass,
       popperId,
       popperStyle,
@@ -86,6 +86,8 @@ export default defineComponent({
         onMouseLeave: onPopperMouseLeave,
         onAfterEnter,
         onAfterLeave,
+        onBeforeEnter,
+        onBeforeLeave,
         visibility,
       },
       [

--- a/packages/popper/src/renderers/popper.ts
+++ b/packages/popper/src/renderers/popper.ts
@@ -20,6 +20,8 @@ interface IRenderPopperProps {
   onMouseLeave: () => void
   onAfterEnter: () => void
   onAfterLeave: () => void
+  onBeforeEnter: () => void
+  onBeforeLeave: () => void
 }
 
 export default function renderPopper(
@@ -40,6 +42,8 @@ export default function renderPopper(
     onMouseLeave,
     onAfterEnter,
     onAfterLeave,
+    onBeforeEnter,
+    onBeforeLeave,
   } = props
 
   const kls = [
@@ -62,8 +66,10 @@ export default function renderPopper(
     Transition,
     {
       name,
-      'onAfter-enter': onAfterEnter,
-      'onAfter-leave': onAfterLeave,
+      'onAfterEnter': onAfterEnter,
+      'onAfterLeave': onAfterLeave,
+      'onBeforeEnter': onBeforeEnter,
+      'onBeforeLeave': onBeforeLeave,
     },
     {
       default: withCtx(() => [withDirectives(
@@ -97,6 +103,6 @@ export default function renderPopper(
         [[vShow, visibility]],
       )]),
     },
-    PatchFlags.PROPS, ['name', 'onAfter-enter', 'onAfter-leave'],
+    PatchFlags.PROPS, ['name', 'onAfterEnter', 'onAfterLeave', 'onBeforeEnter', 'onBeforeLeave'],
   )
 }

--- a/packages/popper/src/use-popper/index.ts
+++ b/packages/popper/src/use-popper/index.ts
@@ -259,7 +259,7 @@ export default function(
     if (isArray(props.trigger)) {
       Object.values(props.trigger).map(mapEvents)
     } else {
-      mapEvents(props.trigger)
+      mapEvents(props.trigger as TriggerType)
     }
   }
 
@@ -284,6 +284,12 @@ export default function(
     onAfterLeave: () => {
       detachPopper()
       emit('after-leave')
+    },
+    onBeforeEnter: () => {
+      emit('before-enter')
+    },
+    onBeforeLeave: () => {
+      emit('before-leave')
     },
     initializePopper,
     isManualMode,

--- a/packages/progress/package.json
+++ b/packages/progress/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/radio-button/package.json
+++ b/packages/radio-button/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/rate/package.json
+++ b/packages/rate/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/row/package.json
+++ b/packages/row/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/scrollbar/package.json
+++ b/packages/scrollbar/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/step/package.json
+++ b/packages/step/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/submenu/package.json
+++ b/packages/submenu/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/tab-pane/package.json
+++ b/packages/tab-pane/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/table-column/package.json
+++ b/packages/table-column/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0-rc.9"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -4,7 +4,7 @@
     "main": "dist/index.js",
     "license": "MIT",
     "peerDependencies": {
-      "vue": "^3.0.0"
+      "vue": "^3.0.3"
     },
     "devDependencies": {
       "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "dependencies": {
-    "vue": "^3.0.0",
+    "vue": "^3.0.3",
     "@vue/test-utils": "^2.0.0-beta.3"
   }
 }

--- a/packages/test-utils/tick.ts
+++ b/packages/test-utils/tick.ts
@@ -7,3 +7,13 @@ const tick = async (times: number) => {
 }
 
 export default tick
+
+// in order to test transitions, we need to use
+// await rAF() after firing transition events.
+export const rAF = async () => {
+  return new Promise(res => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(res)
+    })
+  })
+}

--- a/packages/time-picker/package.json
+++ b/packages/time-picker/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/time-select/package.json
+++ b/packages/time-select/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0-rc.9"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/timeline-item/package.json
+++ b/packages/timeline-item/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/timeline/package.json
+++ b/packages/timeline/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -139,6 +139,7 @@ export default defineComponent({
       ElPopper,
       {
         ref: 'popper',
+        appendToBody: true,
         class: this.class,
         disabled,
         effect,

--- a/packages/transfer/package.json
+++ b/packages/transfer/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/transfer/src/index.vue
+++ b/packages/transfer/src/index.vue
@@ -68,6 +68,8 @@ import { useMove } from './useMove'
 import { UPDATE_MODEL_EVENT } from '@element-plus/utils/constants'
 import { elFormItemKey } from '@element-plus/form'
 
+import { LEFT_CHECK_CHANGE_EVENT, RIGHT_CHECK_CHANGE_EVENT } from './useCheckedChange'
+
 import type { PropType, VNode } from 'vue'
 import type { ElFormItemContext } from '@element-plus/form'
 import type {
@@ -76,8 +78,6 @@ import type {
 } from './transfer'
 
 export const CHANGE_EVENT = 'change'
-export const LEFT_CHECK_CHANGE_EVENT = 'left-check-change'
-export const RIGHT_CHECK_CHANGE_EVENT = 'right-check-change'
 
 export default defineComponent({
   name: 'ElTransfer',

--- a/packages/transfer/src/transfer-panel.vue
+++ b/packages/transfer/src/transfer-panel.vue
@@ -64,9 +64,7 @@ import { t } from '@element-plus/locale'
 import ElCheckbox from '@element-plus/checkbox'
 import ElCheckboxGroup from '@element-plus/checkbox-group'
 import ElInput from '@element-plus/input'
-import { useCheck } from './useCheck'
-
-export const CHECKED_CHANGE_EVENT = 'checked-change'
+import { useCheck, CHECKED_CHANGE_EVENT } from './useCheck'
 
 export default defineComponent({
   name: 'ElTransferPanel',

--- a/packages/transfer/src/transfer.ts
+++ b/packages/transfer/src/transfer.ts
@@ -1,4 +1,4 @@
-import { VNode } from 'vue'
+import type { VNode } from 'vue'
 
 export type Key = string | number
 

--- a/packages/transfer/src/useCheck.ts
+++ b/packages/transfer/src/useCheck.ts
@@ -1,7 +1,8 @@
 import { computed, watch } from 'vue'
 import { TransferPanelProps, TransferPanelState, Key } from './transfer'
 
-import { CHECKED_CHANGE_EVENT } from './transfer-panel.vue'
+export const CHECKED_CHANGE_EVENT = 'checked-change'
+
 
 export const useCheck = (props: TransferPanelProps, panelState: TransferPanelState, emit) => {
 

--- a/packages/transfer/src/useCheckedChange.ts
+++ b/packages/transfer/src/useCheckedChange.ts
@@ -1,7 +1,7 @@
-import { TransferCheckedState, Key } from './transfer'
+export const LEFT_CHECK_CHANGE_EVENT = 'left-check-change'
+export const RIGHT_CHECK_CHANGE_EVENT = 'right-check-change'
 
-import { LEFT_CHECK_CHANGE_EVENT, RIGHT_CHECK_CHANGE_EVENT } from './index.vue'
-
+import type { TransferCheckedState, Key } from './transfer'
 export const useCheckedChange = (checkedState: TransferCheckedState, emit) => {
   const onSourceCheckedChange = (val: Key[], movedKeys: Key[]) => {
     checkedState.leftChecked = val

--- a/packages/transition/package.json
+++ b/packages/transition/package.json
@@ -7,7 +7,7 @@
     "@element-plus/utils": "^0.0.0"
   },
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/tree/__tests__/tree.spec.ts
+++ b/packages/tree/__tests__/tree.spec.ts
@@ -753,13 +753,13 @@ describe('Tree.vue', () => {
             return resolve([{ label: 'region1' }, { label: 'region2' }])
           }
           if (node.level > 4) return resolve([])
-          setTimeout(() => {
+          nextTick(() => {
             resolve([{
               label: 'zone' + this.count++,
             }, {
               label: 'zone' + this.count++,
             }])
-          }, 50)
+          })
         },
         handleNodeOpen(data) {
           this.currentNode = data
@@ -778,13 +778,17 @@ describe('Tree.vue', () => {
     expect(firstNodeWrapper.find('.el-tree-node__children').exists()).toBe(false)
 
     await firstNodeContentWrapper.trigger('click')
-    await sleep(100)
+    await nextTick() // first next tick for UI update
+    await nextTick() // second next tick for triggering loadNode
+    await nextTick() // third next tick for updating props.node.expanded
 
     expect(vm.nodeExpended).toEqual(true)
     expect(vm.currentNode.label).toEqual('region1')
 
     await firstNodeContentWrapper.trigger('click')
-    await sleep(100)
+    await nextTick()
+    await nextTick()
+    await nextTick()
 
     expect(vm.nodeExpended).toEqual(false)
     expect(vm.currentNode.label).toEqual('region1')

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.0"

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,7 +6,7 @@
     "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/scripts/gc.sh
+++ b/scripts/gc.sh
@@ -67,7 +67,7 @@ cat > $DIRNAME/package.json <<EOF
   "main": "dist/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "^3.0.3"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.0.0-beta.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,6 +378,11 @@
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
 
+"@babel/parser@^7.12.0":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.7.tgz#fee7b39fe809d0e73e5b25eecaf5780ef3d73056"
+  integrity sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==
+
 "@babel/parser@^7.12.1":
   version "7.12.3"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz#a305415ebe7a6c7023b40b5122a0662d928334cd"
@@ -960,6 +965,15 @@
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.5.tgz#5d6b4590cfe90c0c8d7396c83ffd9fc28b5a6450"
   integrity sha512-gyTcvz7JFa4V45C0Zklv//GmFOAal5fL23OWpBLqc4nZ4Yrz67s4kCNwSK1Gu0MXGTU8mRY3zJYtacLdKXlzig==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.0":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.7.tgz#6039ff1e242640a29452c9ae572162ec9a8f5d13"
+  integrity sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
@@ -2302,12 +2316,6 @@
   version "4.14.161"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
 
-"@types/mini-css-extract-plugin@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@types/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.1.tgz#d4bdde5197326fca039d418f4bdda03dc74dc451"
-  dependencies:
-    "@types/webpack" "*"
-
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -2375,7 +2383,7 @@
     "@types/source-list-map" "*"
     source-map "^0.7.3"
 
-"@types/webpack@*", "@types/webpack@^4.41.8":
+"@types/webpack@^4.41.8":
   version "4.41.22"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.22.tgz#ff9758a17c6bd499e459b91e78539848c32d0731"
   dependencies:
@@ -2467,33 +2475,36 @@
     html-tags "^3.1.0"
     svg-tags "^1.0.0"
 
-"@vue/compiler-core@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0.tgz#25e4f079cf6c39f83bad23700f814c619105a0f2"
+"@vue/compiler-core@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.3.tgz#dbb4d5eb91f294038f0bed170a1c25f59f7dc74f"
+  integrity sha512-iWlRT8RYLmz7zkg84pTOriNUzjH7XACWN++ImFkskWXWeev29IKi7p76T9jKDaMZoPiGcUZ0k9wayuASWVxOwg==
   dependencies:
-    "@babel/parser" "^7.11.5"
-    "@babel/types" "^7.11.5"
-    "@vue/shared" "3.0.0"
+    "@babel/parser" "^7.12.0"
+    "@babel/types" "^7.12.0"
+    "@vue/shared" "3.0.3"
     estree-walker "^2.0.1"
     source-map "^0.6.1"
 
-"@vue/compiler-dom@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0.tgz#4cbb48fcf1f852daef2babcf9953b681ac463526"
+"@vue/compiler-dom@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.3.tgz#582ba30bc82da8409868bc1153ff0e0e2be617e5"
+  integrity sha512-6GdUbDPjsc0MDZGAgpi4lox+d+aW9/brscwBOLOFfy9wcI9b6yLPmBbjdIsJq3pYdJWbdvACdJ77avBBdHEP8A==
   dependencies:
-    "@vue/compiler-core" "3.0.0"
-    "@vue/shared" "3.0.0"
+    "@vue/compiler-core" "3.0.3"
+    "@vue/shared" "3.0.3"
 
-"@vue/compiler-sfc@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.0.0.tgz#efa38037984bd64aae315828aa5c1248c6eadca9"
+"@vue/compiler-sfc@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.0.3.tgz#7fad9d40e139dd717713c0db701e1eb776f8349f"
+  integrity sha512-YocHSirye85kRVC4lU0+SE6uhrwGJzbhwkrqG4g6kmsAUopZ0qUjbICMlej5bYx2+AUz9yBIM7hpK8nIKFVFjg==
   dependencies:
-    "@babel/parser" "^7.11.5"
-    "@babel/types" "^7.11.5"
-    "@vue/compiler-core" "3.0.0"
-    "@vue/compiler-dom" "3.0.0"
-    "@vue/compiler-ssr" "3.0.0"
-    "@vue/shared" "3.0.0"
+    "@babel/parser" "^7.12.0"
+    "@babel/types" "^7.12.0"
+    "@vue/compiler-core" "3.0.3"
+    "@vue/compiler-dom" "3.0.3"
+    "@vue/compiler-ssr" "3.0.3"
+    "@vue/shared" "3.0.3"
     consolidate "^0.16.0"
     estree-walker "^2.0.1"
     hash-sum "^2.0.0"
@@ -2502,15 +2513,16 @@
     merge-source-map "^1.1.0"
     postcss "^7.0.32"
     postcss-modules "^3.2.2"
-    postcss-selector-parser "^6.0.2"
+    postcss-selector-parser "^6.0.4"
     source-map "^0.6.1"
 
-"@vue/compiler-ssr@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.0.0.tgz#d717abcd23a89fb38d1497228633a21bcf9a0e28"
+"@vue/compiler-ssr@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.0.3.tgz#7d9e5c1b8c71d69865ac6c48d2e6eb2eecb68501"
+  integrity sha512-IjJMoHCiDk939Ix7Q5wrex59TVJr6JFQ95gf36f4G4UrVau0GGY/3HudnWT/6eyWJ7267+odqQs1uCZgDfL/Ww==
   dependencies:
-    "@vue/compiler-dom" "3.0.0"
-    "@vue/shared" "3.0.0"
+    "@vue/compiler-dom" "3.0.3"
+    "@vue/shared" "3.0.3"
 
 "@vue/component-compiler-utils@^3.2.0":
   version "3.2.0"
@@ -2527,30 +2539,34 @@
   optionalDependencies:
     prettier "^1.18.2"
 
-"@vue/reactivity@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0.tgz#fd15632a608650ce2a969c721787e27e2c80aa6b"
+"@vue/reactivity@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.3.tgz#681ee01ceff9219bc4da6bbb7d9c97d452e44d1d"
+  integrity sha512-t39Qmc42MX7wJtf8L6tHlu17eP9Rc5w4aRnxpLHNWoaRxddv/7FBhWqusJ2Bwkk8ixFHOQeejcLMt5G469WYJw==
   dependencies:
-    "@vue/shared" "3.0.0"
+    "@vue/shared" "3.0.3"
 
-"@vue/runtime-core@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0.tgz#480febf1bfe32798b6abbd71a88f8e8b473a51c2"
+"@vue/runtime-core@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.3.tgz#edab3c9ad122cf8afd034b174cd20c073fbf950a"
+  integrity sha512-Fd1JVnYI6at0W/2ERwJuTSq4S22gNt8bKEbICcvCAac7hJUZ1rylThlrhsvrgA+DVkWU01r0niNZQ4UddlNw7g==
   dependencies:
-    "@vue/reactivity" "3.0.0"
-    "@vue/shared" "3.0.0"
+    "@vue/reactivity" "3.0.3"
+    "@vue/shared" "3.0.3"
 
-"@vue/runtime-dom@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0.tgz#e0d1f7c7e22e1318696014cc3501e06b288c2e11"
+"@vue/runtime-dom@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.3.tgz#5e3e5e5418b9defcac988d2be0cf65596fa2cc03"
+  integrity sha512-ytTvSlRaEYvLQUkkpruIBizWIwuIeHER0Ch/evO6kUaPLjZjX3NerVxA40cqJx8rRjb9keQso21U2Jcpk8GsTg==
   dependencies:
-    "@vue/runtime-core" "3.0.0"
-    "@vue/shared" "3.0.0"
+    "@vue/runtime-core" "3.0.3"
+    "@vue/shared" "3.0.3"
     csstype "^2.6.8"
 
-"@vue/shared@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0.tgz#ec089236629ecc0f10346b92f101ff4339169f1a"
+"@vue/shared@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.3.tgz#ef12ebff93a446df281e8a0fd765b5aea8e7745b"
+  integrity sha512-yGgkF7u4W0Dmwri9XdeY50kOowN4UIX7aBQ///jbxx37itpzVjK7QzvD3ltQtPfWaJDGBfssGL0wpAgwX9OJpQ==
 
 "@vue/test-utils@^2.0.0-beta.0", "@vue/test-utils@^2.0.0-beta.3":
   version "2.0.0-beta.4"
@@ -10272,6 +10288,16 @@ postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
+postcss-selector-parser@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz#56075a1380a04604c38b063ea7767a129af5c2b3"
+  integrity sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==
+  dependencies:
+    cssesc "^3.0.0"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+    util-deprecate "^1.0.2"
+
 postcss-svgo@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-4.0.2.tgz#17b997bc711b333bab143aaed3b8d3d6e3d38258"
@@ -12595,7 +12621,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@^1.0.1, util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -12782,9 +12808,10 @@ vue-eslint-parser@^7.1.0:
     esquery "^1.0.1"
     lodash "^4.17.15"
 
-vue-jest@5.0.0-alpha.1:
-  version "5.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/vue-jest/-/vue-jest-5.0.0-alpha.1.tgz#081a20e585420f19b441beb2cb2cd9869ecdfa5b"
+vue-jest@5.0.0-alpha.5:
+  version "5.0.0-alpha.5"
+  resolved "https://registry.npmjs.org/vue-jest/-/vue-jest-5.0.0-alpha.5.tgz#a24b7569ba2078836a316033f283e151afc4906b"
+  integrity sha512-/ddNgiJYEtStK4kfTgIRSpBrkkrFepsCyu6qhIi2ph8rJk8OaI6HJANMjzD2tz2mnGqQOf0mTyZICVfDnLLZHA==
   dependencies:
     "@babel/plugin-transform-modules-commonjs" "^7.2.0"
     chalk "^2.1.0"
@@ -12792,16 +12819,14 @@ vue-jest@5.0.0-alpha.1:
     extract-from-css "^0.4.4"
     ts-jest "^24.0.0"
 
-vue-loader@16.0.0-beta.7:
-  version "16.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-16.0.0-beta.7.tgz#6f2726fa0e2b1fbae67895c47593bbf69f2b9ab8"
+vue-loader@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.0.tgz#e4544abf65cbb3b81f3d5360d95a3e2ae83749a1"
+  integrity sha512-fTtCdI7VeyNK0HP4q4y9Z9ts8TUeaF+2/FjKx8CJ/7/Oem1rCX7zIJe+d+jLrVnVNQjENd3gqmANraLcdRWwnQ==
   dependencies:
-    "@types/mini-css-extract-plugin" "^0.9.1"
-    chalk "^3.0.0"
+    chalk "^4.1.0"
     hash-sum "^2.0.0"
-    loader-utils "^1.2.3"
-    merge-source-map "^1.1.0"
-    source-map "^0.6.1"
+    loader-utils "^2.0.0"
 
 vue-router@^4.0.0-beta.4:
   version "4.0.0-beta.9"
@@ -12818,13 +12843,14 @@ vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
 
-vue@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0.tgz#cfb5df5c34efce319b113a1667d12b74dcfd9c90"
+vue@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.3.tgz#ad94a475e6ebbf3904673b6a0ae46e47b957bd72"
+  integrity sha512-BZG5meD5vLWdvfnRL5WqfDy+cnXO1X/SweModGUna78bdFPZW6+ZO1tU9p0acrskX3DKFcfSp2s4SZnMjABx6w==
   dependencies:
-    "@vue/compiler-dom" "3.0.0"
-    "@vue/runtime-dom" "3.0.0"
-    "@vue/shared" "3.0.0"
+    "@vue/compiler-dom" "3.0.3"
+    "@vue/runtime-dom" "3.0.3"
+    "@vue/shared" "3.0.3"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
* bumping version

* build(core): bumping vue version

- Bumping up vue version from ^3.0.0 to ^3.0.3 due to the change of `emitOptions`

* Remove transition mock/Add before-enter and before-leave hook emitter for popper

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer to relative issues for your PR.
